### PR TITLE
Add rest timeout override to .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,11 @@ TOKEN=your bot's token here
 PREFIX=/
 TRANSCRIPT_FILE=UNSOUNDED Transcription.txt
 ```
+
+If you get timeouts, you can also increase the number of milliseconds with:
+```
+REST_REQUEST_TIMEOUT_MS=30000
+```
+
 3. In the root directory of the project, run `npm i` to install the necessary dependencies.
 4. Run `node farcyte` or (on windows) double-click start.bat.

--- a/farcyte.js
+++ b/farcyte.js
@@ -4,15 +4,19 @@ import { log } from './functions/utils.js';
 import dotenv from 'dotenv'
 dotenv.config()
 
-const client = new Client({ intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES, Intents.FLAGS.DIRECT_MESSAGES], partials: ['CHANNEL'] });
+const client = new Client({
+	intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES, Intents.FLAGS.DIRECT_MESSAGES],
+	partials: ['CHANNEL'],
+	...(/^\d+$/.test(process.env.REST_REQUEST_TIMEOUT_MS) && { restRequestTimeout: parseInt(process.env.REST_REQUEST_TIMEOUT_MS) }) // use defaults or override with .env
+});
 client.commands = new Collection();
 
 const commandFiles = readdirSync('./commands').filter(file => file.endsWith('.js'));
 
 for (const file of commandFiles) {
 	import(`./commands/${file}`).then((command) => {
-    client.commands.set(command.name, command);
-  });
+		client.commands.set(command.name, command);
+	});
 
 }
 


### PR DESCRIPTION
When testing I had issues with the rest client timing out, this should help.